### PR TITLE
Make package more installable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,19 @@
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
 version: 2
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test-3.6
+      - test-3.5
+
 jobs:
-  build:
+  test-3.6: &test-template
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.6-jessie
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -30,7 +37,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            python3 -m venv venv
+            python -m venv venv
             . venv/bin/activate
             pip install -r test_requirements.txt
 
@@ -50,3 +57,8 @@ jobs:
             . venv/bin/activate
             python setup.py test
             coveralls
+
+  test-3.5:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.5-jessie

--- a/ec2_tag_conditional/__init__.py
+++ b/ec2_tag_conditional/__init__.py
@@ -1,2 +1,2 @@
-version_info = (0, 1, 1)
+version_info = (0, 1, 2)
 __version__ = ".".join([str(v) for v in version_info])

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     author_email='sym.roe@democracyclub.org.uk',
     license='MIT',
 
-    python_requires='>=3.6',
+    python_requires='>=2.7',
     classifiers=CLASSIFIERS,
     packages=find_packages(exclude=['tests']),
     include_package_data=True,


### PR DESCRIPTION
Aah the python packaging yak: hairiest yak of them all :D

![](https://images.pexels.com/photos/671931/pexels-photo-671931.jpeg?auto=compress&cs=tinysrgb&h=750&w=1260)

I ran in to several problems trying to install this package in various environments:

```
$ pip install ec2_tag_conditional==0.1.1
Collecting ec2_tag_conditional==0.1.1
  Could not find a version that satisfies the requirement ec2_tag_conditional==0.1.1 (from versions: 0.1.0)
No matching distribution found for ec2_tag_conditional==0.1.1


$ pip install ec2_tag_conditional==0.1.0
Collecting ec2_tag_conditional==0.1.0
  Using cached https://files.pythonhosted.org/packages/94/58/f74dcc6615d9b1b025df288458263fe1f2040987a0c5158ac831768bb1bd/ec2_tag_conditional-0.1.0.tar.gz
ec2-tag-conditional requires Python '>=3.6' but the running Python is 3.5.2
```


I think you're getting away with installing this on python 2.7 here:
https://github.com/DemocracyClub/who_deploy/blob/dfd4d477377a8b3ade9c08af5a9b6fdadeaa79e8/vars.yml#L51
because only `pip>=9.0.0` respects the `python_requires` property and at this early stage of the build you're still interacting with the system pip version distributed by the ubuntu repos by default from ~2 years ago. However when we try to install with a current version of `pip`, it won't let us. The virtual env for all of our main projects (WhoCIVF, WhereDIV, EE) is python 3.5, so we're hitting the issue there trying to use a current version of `pip`.

You'll note that version `0.1.1` and `0.1.0` are throwing completely different errors here. This confused me, but also note that version `0.1.0` is packaged as a [source distribution](https://pypi.org/project/ec2_tag_conditional/0.1.0/#files) whereas version `0.1.1` is packaged as a [wheel](https://pypi.org/project/ec2_tag_conditional/0.1.1/#files).

My initial worry here was that because wheels can include binaries, a wheel packaged on a mac was deemed incompatible with linux and we were going to have to use [manylinux](https://github.com/pypa/manylinux) to build the wheel, but having read a bit more I think the wheel is cross-platform. It may just be that because it is a wheel, `pip` knows that version `0.1.1` is incompatible earlier in the process whereas with the source dist, it has to download it and try to run `setup.py` before it hits the `python_requires` property.

Suggested way forward: merge this, build the wheel for `0.1.2` on your mac, publish it to PyPI and try again.. if its still a fail, we go back to a `sdist`?

As a slight tangent, I've also set up a CircleCI build that tests on python 3.5 and 3.6. I did try to do 2.7 as well but ended up disappearing down a rabbit hole trying configure the virtual env in a python 2/3 compatible way (you can't do `python -m venv` in python 2) and realised I'm now several sub-rabbit holes away from the original thing I was trying to do which was get any version of this module installed in the EveryElection build.. so I decided to give up and ignore that for the moment.